### PR TITLE
[code-edit]:React-FC

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import { Routes, Route, BrowserRouter } from "react-router-dom";
 import { useSelector} from "react-redux";
 import useFetch from "./hooks/useFetch";
@@ -9,7 +10,7 @@ import Main from "./pages/main/Main";
 import Bookmark from "./pages/bookmark/Bookmark";
 import Products from "./pages/products/Products";
 
-function App() {
+const App : FC = () => {
   useFetch('https://dummyjson.com/products?limit=100');
   const isOpen = useSelector((state: RootState) => state.hamburgerModal.isOpen);
   

--- a/project/src/components/button/BookmarkButton.tsx
+++ b/project/src/components/button/BookmarkButton.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import tw from "tailwind-styled-components";
 import { useDispatch } from "react-redux";
 import bookmarkOn from '../../assets/bookmark/bookmark-on.png'
@@ -10,7 +11,8 @@ interface BookmarkButtonProps {
   bookmark?: boolean;
 }
 
-export default function BookmarkButton({id, bookmark} : BookmarkButtonProps) {
+const BookmarkButton : FC<BookmarkButtonProps> = (props) => {
+  const { id, bookmark } = props;
   const dispatch = useDispatch();
   const bookmarkHandler = (id: number) => {
     dispatch(setBookmark(id));
@@ -37,3 +39,5 @@ const BookmarkButtonContainer = tw.button`
   duration-100
   cursor-pointer
 `
+
+export default BookmarkButton;

--- a/project/src/components/filter/Filter.tsx
+++ b/project/src/components/filter/Filter.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import tw from "tailwind-styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../modules";
@@ -13,7 +14,7 @@ import automotive from '../../assets/filter/automotive.png'
 import motocycle from '../../assets/filter/motorcycle.png'
 
 
-export default function Filter() {
+const Filter: FC = () => {
   const dispatch = useDispatch();
   const category = useSelector((state: RootState) => state.filterList.category);
   const tabHandler = (category: CategoryName)=>{
@@ -85,3 +86,5 @@ const FilterText = tw.span`
   text-sm
   font-semibold
 `
+
+export default Filter;

--- a/project/src/components/layout/Footer.tsx
+++ b/project/src/components/layout/Footer.tsx
@@ -1,6 +1,7 @@
+import { FC } from "react";
 import tw from "tailwind-styled-components";
 
-export default function Footer() {
+const Footer : FC = () => {
   return (
     <FooterContainer>
       <FooterText>개인정보 처리방침 | 이용약관</FooterText>
@@ -24,3 +25,5 @@ const FooterText = tw.span`
   text-sm
   text-slate-400
 `;
+
+export default Footer

--- a/project/src/components/layout/Header.tsx
+++ b/project/src/components/layout/Header.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import tw from "tailwind-styled-components";
 import { useDispatch } from "react-redux";
 import { switchModal } from "../../modules/hamburgerModalSlice";
@@ -5,7 +6,7 @@ import { Link } from "react-router-dom";
 import logo from "../../assets/common/logo.png";
 import hamburger from "../../assets/common/hamburger.png";
 
-export default function Header() {
+const Header: FC  = () => {
   const dispatch = useDispatch();
 
   return (
@@ -61,3 +62,6 @@ const Image = tw.img<ImageProps>`
   h-${(props) => props.height}
   cursor-pointer
 `;
+
+
+export default Header;

--- a/project/src/components/modal/HamburgerModal.tsx
+++ b/project/src/components/modal/HamburgerModal.tsx
@@ -1,9 +1,10 @@
+import { FC } from "react";
 import tw from "tailwind-styled-components";
 import { useDispatch } from "react-redux";
 import { closeModal } from "../../modules/hamburgerModalSlice";
 import { Link } from "react-router-dom";
 
-export default function HamburgerModal() {
+const HamburgerModal : FC = () => {
   const dispatch = useDispatch();
 
   return (
@@ -65,3 +66,5 @@ const ModalList = tw.li`
   duration-200
   cursor-pointer
 `;
+
+export default HamburgerModal;

--- a/project/src/components/productCard/ProductCard.tsx
+++ b/project/src/components/productCard/ProductCard.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import tw from "tailwind-styled-components";
 import ApiDataInterFace from "../../modules/apidata.interface";
 import BookmarkButton from "../button/BookmarkButton";
@@ -6,7 +7,9 @@ interface ProductCardProps {
   product: ApiDataInterFace;
 }
 
-export default function ProductCard({ product }: ProductCardProps) {
+const ProductCard : FC<ProductCardProps> = (props) => {
+  const { product } = props;
+
   return (
     <div>
       <ProductImage
@@ -48,3 +51,5 @@ const ProudctPrice = tw.span`
   text-sm
   font-light
 `;
+
+export default ProductCard;

--- a/project/src/pages/bookmark/Bookmark.tsx
+++ b/project/src/pages/bookmark/Bookmark.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import { FC } from "react";
 
-export default function Bookmark() {
-  return <div>Likes</div>;
+const Bookmark : FC = () => {
+  return <div>Bookmark</div>;
 }
+
+export default Bookmark;

--- a/project/src/pages/main/Main.tsx
+++ b/project/src/pages/main/Main.tsx
@@ -1,10 +1,11 @@
+import { FC } from "react";
 import tw from "tailwind-styled-components";
 import { useSelector } from "react-redux";
 import { RootState } from "../../modules";
 import ApiDataInterFace from "../../modules/apidata.interface";
 import ProductCard from "../../components/productCard/ProductCard";
 
-export default function Main() {
+const Main : FC = () => {
   const productList = useSelector((state: RootState)  => state.productList.products);
   const VIEWCOUNT:number = 4;
 
@@ -55,3 +56,5 @@ const ListText = tw.h1`
   rounded-xl
   shadow-lg
 `;
+
+export default Main;

--- a/project/src/pages/products/Products.tsx
+++ b/project/src/pages/products/Products.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import tw from "tailwind-styled-components";
 import Filter from "../../components/filter/Filter";
 import { useSelector } from "react-redux";
@@ -6,7 +7,7 @@ import Categories from "../../types/categories";
 import ApiDataInterFace from "../../modules/apidata.interface";
 import ProductCard from "../../components/productCard/ProductCard";
 
-export default function Products() {
+const Products : FC  = () => {
   const productList = useSelector((state: RootState)  => state.productList.products);
   const category = useSelector((state: RootState) => state.filterList.category);
 
@@ -55,3 +56,5 @@ const ProductCardContainer = tw.div`
   py-5
   mx-14
 `;
+
+export default Products;


### PR DESCRIPTION
# Pull request Summary

#### props Type을 React.FC로 해결하기
- 함수형 컴포넌트의 prop을 interface로 지정하고, 함수의 매개변수에 props의 타입을 지정해주었는데, React.FC를 사용하여 제네릭으로 props의 타입을 넘겨주었습니다.
- <a href="https://react.vlpt.us/using-typescript/02-ts-react-basic.html">벨로퍼트와 함께하는 모던 리액트</a>를 보고 참고하여 해결하였습니다.
##### 코드 수정 전
```
interface ProductCardProps {
  product: ApiDataInterFace;
}

export default function ProductCard({ product }: ProductCardProps) { ... }
```
##### 코드 수정 후
```
interface ProductCardProps {
  product: ApiDataInterFace;
}

const ProductCard : FC<ProductCardProps> = (props) => {
  const { product } = props; 
...
```